### PR TITLE
Missing output for resource `github_actions_environment_variable`

### DIFF
--- a/modules/secrets-and-variables/README.md
+++ b/modules/secrets-and-variables/README.md
@@ -45,6 +45,7 @@ No modules.
 | Name | Description |
 |------|-------------|
 | <a name="output_actions_environment_secrets"></a> [actions\_environment\_secrets](#output\_actions\_environment\_secrets) | Actions environment secrets. |
+| <a name="output_actions_environment_variables"></a> [actions\_environment\_variables](#output\_actions\_environment\_variables) | Actions environment variables. |
 | <a name="output_actions_secrets"></a> [actions\_secrets](#output\_actions\_secrets) | Actions secrets. |
 | <a name="output_actions_variables"></a> [actions\_variables](#output\_actions\_variables) | Actions variables. |
 | <a name="output_codespaces_secrets"></a> [codespaces\_secrets](#output\_codespaces\_secrets) | Codespaces secrets. |

--- a/modules/secrets-and-variables/outputs.tf
+++ b/modules/secrets-and-variables/outputs.tf
@@ -23,6 +23,11 @@ output "actions_variables" {
   value       = github_actions_variable.this
 }
 
+output "actions_environment_variables" {
+  description = "Actions environment variables."
+  value       = github_actions_environment_variable.this
+}
+
 output "codespaces_secrets" {
   description = "Codespaces secrets."
   value = [


### PR DESCRIPTION
Add missing output `actions_environment_variables` to `secrets-and-variables` submodule.